### PR TITLE
Rename UI to Paste Syntax from Syntax Highlighting.

### DIFF
--- a/src/main/java/com/urcodebin/views/paste/CodeView.java
+++ b/src/main/java/com/urcodebin/views/paste/CodeView.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 public class CodeView extends Div implements HasUrlParameter<String> {
 
     private final TextArea sourceCode = new TextArea("Source Code");
-    private final Label syntaxLabel = new Label("Syntax Highlighting:");
+    private final Label syntaxLabel = new Label("Paste Syntax:");
     private final TextField pasteSyntax = new TextField();
     private final Label expirationLabel = new Label("Code Expiration:");
     private final TextField codeExpirationDate = new TextField();

--- a/src/main/java/com/urcodebin/views/paste/PasteView.java
+++ b/src/main/java/com/urcodebin/views/paste/PasteView.java
@@ -39,7 +39,7 @@ public class PasteView extends Div {
 
     private final TextArea sourceCode = new TextArea("Source Code");
     private final TextField pasteTitle = new TextField("Code Title");
-    private final ComboBox<PasteSyntax> pasteSyntax = new ComboBox<>("Syntax Highlighting");
+    private final ComboBox<PasteSyntax> pasteSyntax = new ComboBox<>("Paste Syntax");
     private final ComboBox<PasteExpiration> pasteExpiration = new ComboBox<>("Code Expiration");
     private final ComboBox<PasteVisibility> pasteVisibility = new ComboBox<>("Paste Visibility");
     


### PR DESCRIPTION
UI has not been updated to account for the new changes. Change the UI to use "Paste Syntax" instead of "Syntax Highlighting."